### PR TITLE
Image captioning fails when an image with relative path and without scale is embedded in news item

### DIFF
--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -228,6 +228,30 @@ alert(1);
         self.assertTrue(page.aq_base
                         is uuidToObject(page.UID()).aq_base)
 
+    def test_image_captioning_in_news_item(self):
+        # Create a news item with a relative unscaled image
+        self.portal.invokeFactory('News Item', id='a-news-item', title='Title')
+        news_item = getattr(self.portal, 'a-news-item')
+        news_item.setText('<p><img class="captioned" src="image.jpg"/></p>')
+        news_item.setDescription("Description.")
+
+        # Enable image captioning
+        from zope.interface import implements
+        from zope.component import provideUtility
+        from plone.outputfilters.filters.resolveuid_and_caption import\
+            IImageCaptioningEnabler
+        class ResolveCaptioningEnabler(object):
+            implements(IImageCaptioningEnabler)
+            available = True
+        provideUtility(ResolveCaptioningEnabler(), IImageCaptioningEnabler)
+
+        # Test captioning
+        output = news_item.getText()
+        self.assertEqual(output, """<p><dl style="width:500px;" class="captioned">
+<dt><img src="http://nohost/plone/image.jpg/image" alt="Image" title="Image" height="331" width="500" /></dt>
+ <dd class="image-caption" style="width:500px;">My caption</dd>
+</dl></p>""")
+
     def test_image_captioning_absolutizes_uncaptioned_image(self):
         text_in = """<img src="/image.jpg" />"""
         text_out = """<img src="http://nohost/plone/image.jpg" alt="Image" title="Image" />"""


### PR DESCRIPTION
A corner case, I'd guess. Failing test attached.

How to reproduce (on Plone 4.2)
1. Enable image captioning.
2. Add a new image (e.g. image.jpg).
3. Add a new news item.
4. Embed that image with relative path and without scaling information (e.g. <img class="captioned" src="image.jpg" />
5. Get a stacktrace:
   
   ```
   Module plone.outputfilters.transforms.html_to_plone_outputfilters_html, line 47, in convert
   Module plone.outputfilters, line 6, in apply_filters
   Module plone.outputfilters.filters.resolveuid_and_caption, line 102, in __call__
   Module sgmllib, line 104, in feed
   Module sgmllib, line 138, in goahead
   Module sgmllib, line 296, in parse_starttag
   Module sgmllib, line 338, in finish_starttag
   Module plone.outputfilters.filters.resolveuid_and_caption, line 335, in unknown_starttag
   Module plone.outputfilters.filters.resolveuid_and_caption, line 255, in handle_captioned_image
   Module plone.app.imaging.scaling, line 201, in getImageSize
   
   AttributeError: getSize
   ```

This is caused by the following line accepting the news item object in question as `fullimage`, because news item object has `tag`-method.

https://github.com/plone/plone.outputfilters/blob/master/plone/outputfilters/filters/resolveuid_and_caption.py#L240

Filed a ticket at https://dev.plone.org/ticket/13282
