### PR TITLE
If we have an image description it should go into the alt text of the img

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 1.9 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- If we have an image description it should go into the alt text of the img
+  tag
+  [ale-rt]
 
 
 1.8 (2012-12-10)

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -340,7 +340,7 @@ class ResolveUIDAndCaptionFilter(SGMLParser):
                     # Check to see if the alt / title tags need setting
                     title = aq_acquire(fullimage, 'Title')()
                     if 'alt' not in attributes:
-                        attributes['alt'] = title
+                        attributes['alt'] = description or title
                     if 'title' not in attributes:
                         attributes['title'] = title
                     attrs = attributes.iteritems()


### PR DESCRIPTION
For accessibility the alt attribute in the img tag should provide the image description.
