### PR TITLE
Strip trailing slashes from image src. This fixes images not getting res...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 1.15 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Strip trailing slashes from image src. This fixes images not getting resolved
+  when inserted as original size by plone.app.widgets tinymce.
+  [enfold-josh]
 
 
 1.14 (2014-04-22)

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -190,6 +190,7 @@ class ResolveUIDAndCaptionFilter(SGMLParser):
             # We have a scheme
             return None, None, src, description
 
+        src = src.rstrip('/')
         base = self.context
         subpath = src
         appendix = ''


### PR DESCRIPTION
...olved when inserted as original size by plone.app.widgets tinymce.