### PR TITLE
Add GS dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.16 (unreleased)
------------------
+1.15.1 (unreleased)
+-------------------
 
-- Nothing changed yet.
+- Declare GS dependencies.
+  [do3cc]
 
 
 1.15 (2015-05-11)

--- a/plone/outputfilters/profiles/default/metadata.xml
+++ b/plone/outputfilters/profiles/default/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1</version>
+  <dependencies>
+    <dependency>profile-Products.MimetypesRegistry:MimetypesRegistry</dependency>
+  </dependencies>
+</metadata>

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.16.dev0'
+version = '1.15.1.dev0'
 
 setup(name='plone.outputfilters',
       version=version,


### PR DESCRIPTION
Our test environment showed failures after adding GS 1.8.0
triggered by missing dependencies in this package. I guess somehow
these dependencies get added to plone.outputfilters via some other
way when being  run in coredev.