### PR TITLE
fix: handle error when resolving uid if object is not a content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
-
+- Fixed error when uid resolving if object got didn't have
+  absolute_url method.
+  [Gagaro]
 
 2.1.1 (2015-11-25)
 ------------------

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -249,7 +249,10 @@ class ResolveUIDAndCaptionFilter(SGMLParser):
         if image is None:
             return None, None, src, description
         
-        url = image.absolute_url()
+        try:
+            url = image.absolute_url()
+        except AttributeError:
+            return None, None, src, description
         if isinstance(url, unicode):
             url = url.encode('utf8')
         src = url + appendix


### PR DESCRIPTION
If a link to an image is wrong (to the blob file for example), the object does not have an `absolute_url` method and an exception is raised.