### PR TITLE
Do not build url if href starts with 'tel:'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 New:
 
-- *add item here*
+- Added "tel:" to ignored link types.
+  [julianhandl]
 
 Fixes:
 

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -324,6 +324,7 @@ class ResolveUIDAndCaptionFilter(SGMLParser):
                 scheme = urlsplit(href)[0]
                 if not scheme and not href.startswith('/') \
                         and not href.startswith('mailto<') \
+                        and not href.startswith('tel:') \
                         and not href.startswith('#'):
                     obj, subpath, appendix = self.resolve_link(href)
                     if obj is not None:

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -198,6 +198,10 @@ alert(1);
     def test_resolve_uids_ignores_mailto(self):
         text_in = """<a href="mailto:foo@example.com">foo@example.com</a>"""
         self._assertTransformsTo(text_in, text_in)
+    
+    def test_resolve_uids_ignores_tel(self):
+        text_in = """<a href="tel:+1234567890">+12 345 67890</a>"""
+        self._assertTransformsTo(text_in, text_in)
 
     def test_resolve_uids_handles_junk(self):
         text_in = """<a class="external-link" href="mailto&lt;foo@example.com&gt;">foo@example.com</a>"""


### PR DESCRIPTION
Besides the popular mailto link the tel link gets used more and more. Especially in the age of responsive design it is important to support this kind of link which lets your link trigger a "real" call on your phone or your default communication application (skype, ...) on your desktop pc.