### PR TITLE
Backport bugfixes for `mailto:` and `tel:` into 1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,13 @@ Changelog
 
 New:
 
-- *add item here*
+- Added ``tel:`` to ignored link types.
+  [julianhandl]
 
 Fixes:
 
-- *add item here*
-
+- Explicitly exclude ``mailto:`` links from being UID-resolved.
+  [thet]
 
 1.15.1 (2015-10-28)
 -------------------

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -328,6 +328,8 @@ class ResolveUIDAndCaptionFilter(SGMLParser):
                 scheme = urlsplit(href)[0]
                 if not scheme and not href.startswith('/') \
                         and not href.startswith('mailto<') \
+                        and not href.startswith('mailto:') \
+                        and not href.startswith('tel:') \
                         and not href.startswith('#'):
                     obj, subpath, appendix = self.resolve_link(href)
                     if obj is not None:

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -177,6 +177,10 @@ alert(1);
         text_in = """<a href="mailto:foo@example.com">foo@example.com</a>"""
         self._assertTransformsTo(text_in, text_in)
 
+    def test_resolve_uids_handles_tel(self):
+        text_in = """<a href="tel:+1234567890">+12 345 67890</a>"""
+        self._assertTransformsTo(text_in, text_in)
+
     def test_resolve_uids_handles_junk(self):
         text_in = """<a class="external-link" href="mailto&lt;foo@example.com&gt;">foo@example.com</a>"""
         self._assertTransformsTo(text_in, text_in)

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -173,7 +173,7 @@ alert(1);
 </map>"""
         self._assertTransformsTo(text_in, text_out)
 
-    def test_resolve_uids_ignores_mailto(self):
+    def test_resolve_uids_handles_mailto(self):
         text_in = """<a href="mailto:foo@example.com">foo@example.com</a>"""
         self._assertTransformsTo(text_in, text_in)
 


### PR DESCRIPTION
There were some bugfixes missing out for Plone 4, that are now going to be backported with this pull request. Credits are given to the original authors.

Please note, that I was trying to run the tests, but was unable to do so. It seems like that Products.PloneTestCase is completely deprecated (even for Plone 4) and it should be ported to plone.app.testing as in the master branch. This however is out-of-scope of this current issue and probably should be handled later.