### PR TITLE
Image caption support in Plone 5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-3.1.3 (unreleased)
-------------------
+4.0 (unreleased)
+----------------
 
 Breaking changes:
 
-- *add item here*
+- Change the image caption template to use ``<figure>`` and ``<figcaption>``.
+  [thet]
 
 New features:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add an ``ImageCaptioningEnabler`` utility which can be enabled via the portal registry setting ``plone.image_captioning``.
+  [thet]
 
 Bug fixes:
 

--- a/plone/outputfilters/browser/captioned_image.pt
+++ b/plone/outputfilters/browser/captioned_image.pt
@@ -1,8 +1,6 @@
-<dl tal:attributes="class options/class;">
-<dt><a tal:omit-tag="options/isfullsize" rel="lightbox"
-   tal:attributes="href options/url_path;"
-   tal:content="structure options/tag">[image goes here]</a></dt>
- <dd class="image-caption"
-     tal:content="options/caption|nothing">
- </dd>
-</dl>
+<figure tal:attributes="class options/class;">
+  <a tal:omit-tag="options/isfullsize" rel="lightbox"
+      tal:attributes="href options/url_path;"
+      tal:content="structure options/tag">[image goes here]</a>
+  <figcaption class="image-caption" tal:content="options/caption|nothing"></figcaption>
+</figure>

--- a/plone/outputfilters/filters/configure.zcml
+++ b/plone/outputfilters/filters/configure.zcml
@@ -15,4 +15,7 @@
            name="plone5-always-enabled"
            zcml:condition="have plone-5" />
 
+  <utility factory=".resolveuid_and_caption.ImageCaptioningEnabler"
+           name="image-captioning-enabler" />
+
 </configure>

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -7,6 +7,7 @@ from DocumentTemplate.DT_Util import html_quote
 from DocumentTemplate.DT_Var import newline_to_br
 from plone.outputfilters.browser.resolveuid import uuidToObject
 from plone.outputfilters.interfaces import IFilter
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFPlone.utils import safe_unicode
 from six.moves.urllib.parse import unquote
@@ -17,6 +18,7 @@ from zExceptions import NotFound
 from ZODB.POSException import ConflictError
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getAllUtilitiesRegisteredFor
+from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.interface import Attribute
 from zope.interface import implementer
@@ -48,9 +50,20 @@ class IResolveUidsEnabler(Interface):
         "Boolean indicating whether UID links should be resolved.")
 
 
+@implementer(IImageCaptioningEnabler)
+class ImageCaptioningEnabler(object):
+
+    @property
+    def available(self):
+        name = 'plone.image_captioning'
+        registry = getUtility(IRegistry)
+        if name in registry:
+            return registry[name]
+        return False
+
+
 @implementer(IResolveUidsEnabler)
 class ResolveUidsAlwaysEnabled(object):
-
     available = True
 
 
@@ -295,9 +308,9 @@ class ResolveUIDAndCaptionFilter(object):
         klass = ' '.join(attributes['class'])
         del attributes['class']
         del attributes['src']
-        if 'width' in attributes:
+        if 'width' in attributes and attributes['width']:
             attributes['width'] = int(attributes['width'])
-        if 'height' in attributes:
+        if 'height' in attributes and attributes['height']:
             attributes['height'] = int(attributes['height'])
         view = fullimage.unrestrictedTraverse('@@images', None)
         if view is not None:

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -266,10 +266,10 @@ alert(1);
 
         # Test captioning
         output = news_item.text.output
-        text_out = """<span><dl class="captioned">
-<dt><img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>
+        text_out = """<span><figure class="captioned">
+<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>
 </span>"""
         self._assertTransformsTo(output, text_out)
 
@@ -280,18 +280,18 @@ alert(1);
 
     def test_image_captioning_absolute_path(self):
         text_in = """<img class="captioned" src="/image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_relative_path(self):
         text_in = """<img class="captioned" src="image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_relative_path_private_folder(self):
@@ -309,42 +309,42 @@ alert(1);
         self.logout()
 
         text_in = """<img class="captioned" src="private/image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img alt="My private image caption" height="331" src="http://nohost/plone/private/image.jpg/@@images/...jpeg" title="Image" width="500"/></dt>
-<dd class="image-caption">My private image caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img alt="My private image caption" height="331" src="http://nohost/plone/private/image.jpg/@@images/...jpeg" title="Image" width="500"/>
+<figcaption class="image-caption">My private image caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_relative_path_scale(self):
         text_in = """<img class="captioned" src="image.jpg/@@images/image/thumb"/>"""
-        text_out = """<dl class="captioned">
-<dt><a href="/plone/image.jpg" rel="lightbox"><img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/></a></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<a href="/plone/image.jpg" rel="lightbox"><img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/></a>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid(self):
         text_in = """<img class="captioned" src="resolveuid/%s"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_scale(self):
         text_in = """<img class="captioned" src="resolveuid/%s/@@images/image/thumb"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><a href="/plone/image.jpg" rel="lightbox"><img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/></a></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<a href="/plone/image.jpg" rel="lightbox"><img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/></a>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_new_scale(self):
         text_in = """<img class="captioned" src="resolveuid/%s/@@images/image/thumb"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><a href="/plone/image.jpg" rel="lightbox"><img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/></a></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<a href="/plone/image.jpg" rel="lightbox"><img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/></a>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_new_scale_plone_namedfile(self):
@@ -355,10 +355,10 @@ alert(1);
 
     def test_image_captioning_resolveuid_no_scale(self):
         text_in = """<img class="captioned" src="resolveuid/%s/@@images/image"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="500"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_no_scale_plone_namedfile(self):
@@ -385,26 +385,26 @@ alert(1);
 
     def test_image_captioning_preserves_custom_attributes(self):
         text_in = """<img class="captioned" width="42" height="42" foo="bar" src="image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img alt="My caption" foo="bar" height="42" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="42"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img alt="My caption" foo="bar" height="42" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="42"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_handles_unquoted_attributes(self):
         text_in = """<img class=captioned height=144 alt="picture alt text" src="resolveuid/%s" width=120 />""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><img alt="picture alt text" height="144" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="120"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img alt="picture alt text" height="144" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="120"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_preserves_existing_links(self):
         text_in = """<a href="/xyzzy" class="link"><img class="image-left captioned" src="image.jpg/@@images/image/thumb"/></a>"""
-        text_out = """<a class="link" href="/xyzzy"><dl class="image-left captioned">
-<dt><img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/></dt>
-<dd class="image-caption">My caption</dd>
-</dl>
+        text_out = """<a class="link" href="/xyzzy"><figure class="image-left captioned">
+<img alt="My caption" height="84" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Image" width="128"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>
 </a>"""
         self._assertTransformsTo(text_in, text_out)
 
@@ -413,10 +413,10 @@ alert(1);
         self.portal['image.jpg'].setDescription(
             u'Kupu Test Image \xe5\xe4\xf6')
         text_in = """<img class="captioned" src="image.jpg"/>"""
-        text_out = u"""<dl class="captioned">
-<dt><img alt="Kupu Test Image \xe5\xe4\xf6" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Kupu Test Image \xe5\xe4\xf6" width="500"/></dt>
-<dd class="image-caption">Kupu Test Image \xe5\xe4\xf6</dd>
-</dl>"""
+        text_out = u"""<figure class="captioned">
+<img alt="Kupu Test Image \xe5\xe4\xf6" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" title="Kupu Test Image \xe5\xe4\xf6" width="500"/>
+<figcaption class="image-caption">Kupu Test Image \xe5\xe4\xf6</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_resolve_uids_with_bigU(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os
 
 
-version = '3.1.3.dev0'
+version = '4.0.dev0'
 
 setup(
     name='plone.outputfilters',


### PR DESCRIPTION
- Change the image caption template to use ``<figure>`` and ``<figcaption>``.
- Add an ``ImageCaptioningEnabler`` utility which can be enabled via the portal registry setting ``plone.image_captioning``.


Merge:
https://github.com/plone/mockup/pull/911
https://github.com/plone/plone.staticresources/pull/30
https://github.com/plone/Products.CMFPlone/pull/2887
https://github.com/plone/plone.outputfilters/pull/36