### PR TITLE
Image caption support in Plone 5.1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,14 +8,6 @@ Changelog
 
 .. towncrier release notes start
 
-X (2020-05-21)
---------------
-
-New features:
-
-
-- - Change the image caption template to use ``<figure>`` and ``<figcaption>``. (#37)
-
 
 3.0.5 (2018-06-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,14 @@ Changelog
 
 .. towncrier release notes start
 
+X (2020-05-21)
+--------------
+
+New features:
+
+
+- - Change the image caption template to use ``<figure>`` and ``<figcaption>``. (#37)
+
 
 3.0.5 (2018-06-04)
 ------------------

--- a/news/37.feature
+++ b/news/37.feature
@@ -1,0 +1,1 @@
+- Change the image caption template to use ``<figure>`` and ``<figcaption>``.

--- a/plone/outputfilters/browser/captioned_image.pt
+++ b/plone/outputfilters/browser/captioned_image.pt
@@ -1,8 +1,6 @@
-<dl tal:attributes="class options/class;">
-<dt><a tal:omit-tag="options/isfullsize" rel="lightbox"
-   tal:attributes="href options/url_path;"
-   tal:content="structure options/tag">[image goes here]</a></dt>
- <dd class="image-caption"
-     tal:content="options/caption|nothing">
- </dd>
-</dl>
+<figure tal:attributes="class options/class;">
+  <a tal:omit-tag="options/isfullsize" rel="lightbox"
+      tal:attributes="href options/url_path;"
+      tal:content="structure options/tag">[image goes here]</a>
+  <figcaption class="image-caption" tal:content="options/caption|nothing"></figcaption>
+</figure>

--- a/plone/outputfilters/filters/configure.zcml
+++ b/plone/outputfilters/filters/configure.zcml
@@ -15,4 +15,7 @@
            name="plone5-always-enabled"
            zcml:condition="have plone-5" />
 
+  <utility factory=".resolveuid_and_caption.ImageCaptioningEnabler"
+           name="image-captioning-enabler" />
+
 </configure>

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -7,6 +7,7 @@ from DocumentTemplate.DT_Util import html_quote
 from DocumentTemplate.DT_Var import newline_to_br
 from plone.outputfilters.browser.resolveuid import uuidToObject
 from plone.outputfilters.interfaces import IFilter
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import IContentish
 from sgmllib import SGMLParseError
 from sgmllib import SGMLParser
@@ -19,6 +20,7 @@ from zExceptions import NotFound
 from ZODB.POSException import ConflictError
 from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getAllUtilitiesRegisteredFor
+from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.interface import Attribute
 from zope.interface import implementer
@@ -48,6 +50,18 @@ class IImageCaptioningEnabler(Interface):
 class IResolveUidsEnabler(Interface):
     available = Attribute(
         "Boolean indicating whether UID links should be resolved.")
+
+
+@implementer(IImageCaptioningEnabler)
+class ImageCaptioningEnabler(object):
+
+    @property
+    def available(self):
+        name = 'plone.image_captioning'
+        registry = getUtility(IRegistry)
+        if name in registry:
+            return registry[name]
+        return False
 
 
 @implementer(IResolveUidsEnabler)
@@ -275,9 +289,9 @@ class ResolveUIDAndCaptionFilter(SGMLParser):
         klass = attributes['class']
         del attributes['class']
         del attributes['src']
-        if 'width' in attributes:
+        if 'width' in attributes and attributes['width']:
             attributes['width'] = int(attributes['width'])
-        if 'height' in attributes:
+        if 'height' in attributes and attributes['height']:
             attributes['height'] = int(attributes['height'])
         view = fullimage.unrestrictedTraverse('@@images', None)
         if view is not None:

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -260,10 +260,10 @@ alert(1);
 
         # Test captioning
         output = news_item.text.output
-        self.assertRegexpMatches(output, r"""<span><dl class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/(.*?)\.jpeg" alt="Image" title="Image" height="331" width="500"( ?)/></dt>
- <dd class="image-caption">My caption</dd>
-</dl>
+        self.assertRegexpMatches(output, r"""<span><figure class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/(.*?)\.jpeg" alt="Image" title="Image" height="331" width="500"( ?)/>
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>
 </span>""")
 
     def test_image_captioning_absolutizes_uncaptioned_image(self):
@@ -273,18 +273,18 @@ alert(1);
 
     def test_image_captioning_absolute_path(self):
         text_in = """<img class="captioned" src="/image.jpg"/>"""
-        text_out = """<dl  class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/...jpeg" alt="Image" title="Image" height="331" width="500" /></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure  class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/...jpeg" alt="Image" title="Image" height="331" width="500"/>
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_relative_path(self):
         text_in = """<img class="captioned" src="image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/...jpeg" alt="Image" title="Image" height="331" width="500" /></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/...jpeg" alt="Image" title="Image" height="331" width="500" />
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_relative_path_private_folder(self):
@@ -302,42 +302,42 @@ alert(1);
         self.logout()
 
         text_in = """<img class="captioned" src="private/image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img src="http://nohost/plone/private/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="331" width="500" /></dt>
- <dd class="image-caption">My private image caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img src="http://nohost/plone/private/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="331" width="500" />
+ <figcaption class="image-caption">My private image caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_relative_path_scale(self):
         text_in = """<img class="captioned" src="image.jpg/@@images/image/thumb"/>"""
-        text_out = """<dl class="captioned">
-<dt><a rel="lightbox" href="/plone/image.jpg"><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" /></a></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<a rel="lightbox" href="/plone/image.jpg"><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" /></a>
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid(self):
         text_in = """<img class="captioned" src="resolveuid/%s"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="331" width="500" /></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="331" width="500" />
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_scale(self):
         text_in = """<img class="captioned" src="resolveuid/%s/@@images/image/thumb"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><a rel="lightbox" href="/plone/image.jpg"><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" /></a></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<a rel="lightbox" href="/plone/image.jpg"><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" /></a>
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_new_scale(self):
         text_in = """<img class="captioned" src="resolveuid/%s/@@images/image/thumb"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><a rel="lightbox" href="/plone/image.jpg"><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" /></a></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<a rel="lightbox" href="/plone/image.jpg"><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" /></a>
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_new_scale_plone_namedfile(self):
@@ -348,10 +348,10 @@ alert(1);
 
     def test_image_captioning_resolveuid_no_scale(self):
         text_in = """<img class="captioned" src="resolveuid/%s/@@images/image"/>""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="331" width="500" /></dt>
-<dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="331" width="500" />
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_no_scale_plone_namedfile(self):
@@ -378,26 +378,26 @@ alert(1);
 
     def test_image_captioning_preserves_custom_attributes(self):
         text_in = """<img class="captioned" width="42" height="42" foo="bar" src="image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="42" width="42" foo="bar" /></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="42" width="42" foo="bar" />
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_handles_unquoted_attributes(self):
         text_in = """<img class=captioned height=144 alt="picture alt text" src="resolveuid/%s" width=120 />""" % self.UID
-        text_out = """<dl class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="picture alt text" title="Image" height="144" width="120" /></dt>
- <dd class="image-caption">My caption</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="picture alt text" title="Image" height="144" width="120" />
+ <figcaption class="image-caption">My caption</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_preserves_existing_links(self):
         text_in = """<a href="/xyzzy" class="link"><img class="image-left captioned" src="image.jpg/@@images/image/thumb"/></a>"""
-        text_out = """<a href="/xyzzy" class="link"><dl class="image-left captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" /></dt>
- <dd class="image-caption">My caption</dd>
-</dl></a>"""
+        text_out = """<a href="/xyzzy" class="link"><figure class="image-left captioned">
+<img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="84" width="128" />
+ <figcaption class="image-caption">My caption</figcaption>
+</figure></a>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_handles_non_ascii(self):
@@ -405,10 +405,10 @@ alert(1);
         self.portal['image.jpg'].setDescription(
             u'Kupu Test Image \xe5\xe4\xf6')
         text_in = """<img class="captioned" src="image.jpg"/>"""
-        text_out = """<dl class="captioned">
-<dt><img src="http://nohost/plone/image.jpg/@@images/...jpeg" alt="Kupu Test Image \xc3\xa5\xc3\xa4\xc3\xb6" title="Kupu Test Image \xc3\xa5\xc3\xa4\xc3\xb6" height="331" width="500" /></dt>
- <dd class="image-caption">Kupu Test Image \xc3\xa5\xc3\xa4\xc3\xb6</dd>
-</dl>"""
+        text_out = """<figure class="captioned">
+<img src="http://nohost/plone/image.jpg/@@images/...jpeg" alt="Kupu Test Image \xc3\xa5\xc3\xa4\xc3\xb6" title="Kupu Test Image \xc3\xa5\xc3\xa4\xc3\xb6" height="331" width="500" />
+ <figcaption class="image-caption">Kupu Test Image \xc3\xa5\xc3\xa4\xc3\xb6</figcaption>
+</figure>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_resolve_uids_with_bigU(self):

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -274,7 +274,7 @@ alert(1);
     def test_image_captioning_absolute_path(self):
         text_in = """<img class="captioned" src="/image.jpg"/>"""
         text_out = """<figure  class="captioned">
-<img src="http://nohost/plone/image.jpg/@@images/...jpeg" alt="Image" title="Image" height="331" width="500"/>
+<img src="http://nohost/plone/image.jpg/@@images/....jpeg" alt="Image" title="Image" height="331" width="500" />
  <figcaption class="image-caption">My caption</figcaption>
 </figure>"""
         self._assertTransformsTo(text_in, text_out)

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -248,24 +248,6 @@ alert(1);
         self.assertTrue(page.aq_base
                         is uuidToObject(page.UID()).aq_base)
 
-    def test_image_captioning_in_news_item(self):
-        # Create a news item with a relative unscaled image
-        self.portal.invokeFactory('News Item', id='a-news-item', title='Title')
-        news_item = self.portal['a-news-item']
-        from plone.app.textfield.value import RichTextValue
-        news_item.text = RichTextValue(
-            '<span><img class="captioned" src="image.jpg"/></span>',
-            'text/html', 'text/x-html-safe')
-        news_item.setDescription("Description.")
-
-        # Test captioning
-        output = news_item.text.output
-        self.assertRegexpMatches(output, r"""<span><figure class="captioned">
-<img src="http://nohost/plone/image.jpg/@@images/(.*?)\.jpeg" alt="Image" title="Image" height="331" width="500"( ?)/>
- <figcaption class="image-caption">My caption</figcaption>
-</figure>
-</span>""")
-
     def test_image_captioning_absolutizes_uncaptioned_image(self):
         text_in = """<img src="/image.jpg" />"""
         text_out = """<img src="http://nohost/plone/image.jpg" alt="My caption" title="Image" />"""


### PR DESCRIPTION
- Change the image caption template to use &lt;figure> and &lt;figcaption>.

- Add an ImageCaptioningEnabler utility which can be enabled via the portal registry setting plone.image_captioning.

Merge with:
https://github.com/plone/mockup/pull/978
https://github.com/plone/Products.CMFPlone/pull/3099
https://github.com/plone/plone.outputfilters/pull/38
https://github.com/plone/plone.app.upgrade/pull/232