### PR TITLE
Check for -a- tag in captioned image.

### DIFF
--- a/news/39.bugfix
+++ b/news/39.bugfix
@@ -1,0 +1,1 @@
+fix AttributeError: 'NoneType' object has no attribute 'unwrap' exception when a fullsize image is wrapped in an <a> tag. [flipmcf]

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -347,7 +347,8 @@ class ResolveUIDAndCaptionFilter(object):
 
         # if we are a captioned image within a link, remove and occurrences
         # of a tags inside caption template to preserve the outer link
-        if bool(elem.find_parent('a')):
+        if bool(elem.find_parent('a')) and \
+           bool(captioned.find('a')):
             captioned.a.unwrap()
 
         elem.replace_with(captioned)


### PR DESCRIPTION
Before unwrapping, see if there is something to unwrap.
Fixes #39 