### PR TITLE
Fixed deprecation warning for html_quote.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for html_quote.
+[maurits]

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -3,7 +3,7 @@ from Acquisition import aq_acquire
 from Acquisition import aq_base
 from Acquisition import aq_parent
 from bs4 import BeautifulSoup
-from DocumentTemplate.DT_Util import html_quote
+from DocumentTemplate.html_quote import html_quote
 from DocumentTemplate.DT_Var import newline_to_br
 from plone.outputfilters.browser.resolveuid import uuidToObject
 from plone.outputfilters.interfaces import IFilter


### PR DESCRIPTION
```
DeprecationWarning: html_quote is deprecated.
Please import from DocumentTemplate.html_quote.
These shims will go away in DocumentTemplate 4.0.
```