### PR TITLE
Resolve UID links in <source src= / srcset=> tags

### DIFF
--- a/news/47.feature
+++ b/news/47.feature
@@ -1,0 +1,1 @@
+Resolve UIDs in SRC= attribute of of SOURCE and IFRAME elements.

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -157,7 +157,9 @@ class ResolveUIDAndCaptionFilter(object):
                     actual_url = relative_root.absolute_url()
                     href = urljoin(actual_url + '/', subpath) + appendix
                 attributes['href'] = href
-        for elem in soup.find_all(['source']):
+        for elem in soup.find_all(['source', 'iframe']):
+            # SOURCE is used for video and audio.
+            # IFRAME is used to embed PDFs.
             attributes = elem.attrs
             attrn = 'src'
             src = attributes.get(attrn)

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -173,28 +173,24 @@ class ResolveUIDAndCaptionFilter(object):
             scheme = url_parts[0]
             # we are only interested in path and beyond /foo/bar?x=2#abc
             path_parts = urlunsplit(['', ''] + list(url_parts[2:]))
-            if not src.startswith('mailto<') \
-                    and not src.startswith('mailto:') \
-                    and not src.startswith('tel:') \
-                    and not src.startswith('#'):
-                obj, subpath, appendix = self.resolve_link(path_parts)
-                if obj is not None:
-                    src = obj.absolute_url()
-                    if subpath:
-                        src += '/' + subpath
-                    src += appendix
-                elif resolveuid_re.match(src) is None \
-                        and not scheme \
-                        and not src.startswith('/'):
-                    # absolutize relative URIs; this text isn't necessarily
-                    # being rendered in the context where it was stored
-                    relative_root = self.context
-                    if not getattr(
-                            self.context, 'isPrincipiaFolderish', False):
-                        relative_root = aq_parent(self.context)
-                    actual_url = relative_root.absolute_url()
-                    src = urljoin(actual_url + '/', subpath) + appendix
-                attributes[attrn] = src
+            obj, subpath, appendix = self.resolve_link(path_parts)
+            if obj is not None:
+                src = obj.absolute_url()
+                if subpath:
+                    src += '/' + subpath
+                src += appendix
+            elif resolveuid_re.match(src) is None \
+                    and not scheme \
+                    and not src.startswith('/'):
+                # absolutize relative URIs; this text isn't necessarily
+                # being rendered in the context where it was stored
+                relative_root = self.context
+                if not getattr(
+                        self.context, 'isPrincipiaFolderish', False):
+                    relative_root = aq_parent(self.context)
+                actual_url = relative_root.absolute_url()
+                src = urljoin(actual_url + '/', subpath) + appendix
+            attributes[attrn] = src
         for elem in soup.find_all('img'):
             attributes = elem.attrs
             src = attributes.get('src', '')

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -168,10 +168,10 @@ class ResolveUIDAndCaptionFilter(object):
                 continue
             # https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
             # [(src1, 480w), (src2, 360w)]
-            srcs += [['srcset'] + s.strip().split() for s in srcset.strip().split(',') if s.strip()]
+            srcs += [s.strip().split() for s in srcset.strip().split(',') if s.strip()]
             for n, elm in enumerate(srcs):
-                srcs[n][1] = r(elm[1])
-            attributes['srcset'] = ','.join(' '.join(s[1:]) for s in srcs)
+                srcs[n][0] = r(elm[0])
+            attributes['srcset'] = ','.join(' '.join(s) for s in srcs)
         for elem in soup.find_all(['source', 'iframe', 'audio', 'video']):
             # SOURCE is used for video and audio.
             # AUDIO/VIDEO can also have src attribute.

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -121,7 +121,7 @@ class ResolveUIDAndCaptionFilter(object):
         else:
             return '<' + tag + '></' + tag + '>'
 
-    def _render_resolveuid(href):
+    def _render_resolveuid(self, href):
         url_parts = urlsplit(href)
         scheme = url_parts[0]
         path_parts = urlunsplit(['', ''] + list(url_parts[2:]))

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -168,7 +168,7 @@ class ResolveUIDAndCaptionFilter(object):
                 continue
             # https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
             # [(src1, 480w), (src2, 360w)]
-            srcs += [s.strip().split() for s in srcset.strip().split(',') if s.strip()]
+            srcs = [s.strip().split() for s in srcset.strip().split(',') if s.strip()]
             for n, elm in enumerate(srcs):
                 srcs[n][0] = r(elm[0])
             attributes['srcset'] = ','.join(' '.join(s) for s in srcs)

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -157,6 +157,42 @@ class ResolveUIDAndCaptionFilter(object):
                     actual_url = relative_root.absolute_url()
                     href = urljoin(actual_url + '/', subpath) + appendix
                 attributes['href'] = href
+        for elem in soup.find_all(['source']):
+            attributes = elem.attrs
+            attrn = 'src'
+            src = attributes.get(attrn)
+            # an 'a' anchor element has no href
+            if not src:
+                attrn = 'srcset'
+                src = attributes.get(attrn)
+                if not src:
+                    continue
+            url_parts = urlsplit(src)
+            scheme = url_parts[0]
+            # we are only interested in path and beyond /foo/bar?x=2#abc
+            path_parts = urlunsplit(['', ''] + list(url_parts[2:]))
+            if not src.startswith('mailto<') \
+                    and not src.startswith('mailto:') \
+                    and not src.startswith('tel:') \
+                    and not src.startswith('#'):
+                obj, subpath, appendix = self.resolve_link(path_parts)
+                if obj is not None:
+                    src = obj.absolute_url()
+                    if subpath:
+                        src += '/' + subpath
+                    src += appendix
+                elif resolveuid_re.match(src) is None \
+                        and not scheme \
+                        and not src.startswith('/'):
+                    # absolutize relative URIs; this text isn't necessarily
+                    # being rendered in the context where it was stored
+                    relative_root = self.context
+                    if not getattr(
+                            self.context, 'isPrincipiaFolderish', False):
+                        relative_root = aq_parent(self.context)
+                    actual_url = relative_root.absolute_url()
+                    src = urljoin(actual_url + '/', subpath) + appendix
+                attributes[attrn] = src
         for elem in soup.find_all('img'):
             attributes = elem.attrs
             src = attributes.get('src', '')

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -159,9 +159,9 @@ class ResolveUIDAndCaptionFilter(object):
                     and not href.startswith('tel:') \
                     and not href.startswith('#'):
                 attributes['href'] = r(href)
-        for elem in soup.find_all(['source', 'iframe', 'img']):
+        for elem in soup.find_all(['source', 'img']):
             # SOURCE is used for video and audio.
-            # IFRAME is used to embed PDFs.
+            # SRCSET specified multiple images (see below).
             attributes = elem.attrs
             srcset = attributes.get('srcset')
             if not srcset:
@@ -172,8 +172,9 @@ class ResolveUIDAndCaptionFilter(object):
             for n, elm in enumerate(srcs):
                 srcs[n][1] = r(elm[1])
             attributes['srcset'] = ','.join(' '.join(s[1:]) for s in srcs)
-        for elem in soup.find_all(['source', 'iframe']):
+        for elem in soup.find_all(['source', 'iframe', 'audio', 'video']):
             # SOURCE is used for video and audio.
+            # AUDIO/VIDEO can also have src attribute.
             # IFRAME is used to embed PDFs.
             attributes = elem.attrs
             src = attributes.get('src')

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -362,6 +362,7 @@ alert(1);
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_with_srcset_and_src(self):
+        self._makeDummyContent()
         text_in = """<img class="captioned" src="resolveuid/%s" srcset="resolveuid/%s 480w,resolveuid/%s 360w"/>""" % (self.UID, self.UID, self.UID)
         text_out = """<figure class="captioned">
 <img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" srcset="http://nohost/plone/image.jpg/@@images/...jpeg 480w,http://nohost/plone/image.jpg/@@images/...jpeg 360w" title="Image" width="500"/>

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -371,17 +371,17 @@ alert(1);
 
     def test_iframe_resolveuid(self):
         text_in = """<iframe src="resolveuid/%s"/>""" % self.UID
-        text_out = """<iframe src="http://nohost/plone/image.jpg"/>"""
+        text_out = """<iframe src="http://nohost/plone/image.jpg"></iframe>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_video_resolveuid(self):
         text_in = """<video src="resolveuid/%s"/>""" % self.UID
-        text_out = """<video src="http://nohost/plone/image.jpg"/>"""
+        text_out = """<video src="http://nohost/plone/image.jpg"></video>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_audio_resolveuid(self):
         text_in = """<audio src="resolveuid/%s"/>""" % self.UID
-        text_out = """<audio src="http://nohost/plone/image.jpg"/>"""
+        text_out = """<audio src="http://nohost/plone/image.jpg"></audio>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_source_resolveuid(self):
@@ -390,8 +390,8 @@ alert(1);
         self._assertTransformsTo(text_in, text_out)
 
     def test_source_resolveuid_srcset(self):
-        text_in = """<video><source srcset="resolveuid/%s" mimetype="video/mp4"/></video>""" % self.UID
-        text_out = """<video><source srcset="http://nohost/plone/image.jpg" mimetype="video/mp4"/></video>"""
+        text_in = """<video><source mimetype="video/mp4" srcset="resolveuid/%s"/></video>""" % self.UID
+        text_out = """<video><source mimetype="video/mp4" srcset="http://nohost/plone/image.jpg"/></video>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_no_scale_plone_namedfile(self):

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -361,6 +361,14 @@ alert(1);
 </figure>"""
         self._assertTransformsTo(text_in, text_out)
 
+    def test_image_captioning_resolveuid_with_srcset_and_src(self):
+        text_in = """<img class="captioned" src="resolveuid/%s" srcset="resolveuid/%s 480w,resolveuid/%s 360w"/>""" % (self.UID, self.UID, self.UID)
+        text_out = """<figure class="captioned">
+<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" srcset="http://nohost/plone/image.jpg/@@images/...jpeg 480w,http://nohost/plone/image.jpg/@@images/...jpeg 360w" title="Image" width="500"/>
+<figcaption class="image-caption">My caption</figcaption>
+</figure>"""
+        self._assertTransformsTo(text_in, text_out)
+
     def test_image_captioning_resolveuid_no_scale_plone_namedfile(self):
         self._makeDummyContent()
         text_in = """<img class="captioned" src="resolveuid/foo2/@@images/image"/>"""

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -371,27 +371,27 @@ alert(1);
 
     def test_iframe_resolveuid(self):
         text_in = """<iframe src="resolveuid/%s"/>""" % self.UID
-        text_out = """<iframe src="http://nohost/plone/image.jpg/@@images/...jpeg"/>"""
+        text_out = """<iframe src="http://nohost/plone/image.jpg"/>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_video_resolveuid(self):
         text_in = """<video src="resolveuid/%s"/>""" % self.UID
-        text_out = """<video src="http://nohost/plone/image.jpg/@@images/...jpeg"/>"""
+        text_out = """<video src="http://nohost/plone/image.jpg"/>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_audio_resolveuid(self):
         text_in = """<audio src="resolveuid/%s"/>""" % self.UID
-        text_out = """<audio src="http://nohost/plone/image.jpg/@@images/...jpeg"/>"""
+        text_out = """<audio src="http://nohost/plone/image.jpg"/>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_source_resolveuid(self):
         text_in = """<video><source src="resolveuid/%s"/></video>""" % self.UID
-        text_out = """<video><source src="http://nohost/plone/image.jpg/@@images/...jpeg"/></video>"""
+        text_out = """<video><source src="http://nohost/plone/image.jpg"/></video>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_source_resolveuid_srcset(self):
         text_in = """<video><source srcset="resolveuid/%s" mimetype="video/mp4"/></video>""" % self.UID
-        text_out = """<video><source srcset="http://nohost/plone/image.jpg/@@images/...jpeg" mimetype="video/mp4"/></video>"""
+        text_out = """<video><source srcset="http://nohost/plone/image.jpg" mimetype="video/mp4"/></video>"""
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_no_scale_plone_namedfile(self):

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -369,6 +369,31 @@ alert(1);
 </figure>"""
         self._assertTransformsTo(text_in, text_out)
 
+    def test_iframe_resolveuid(self):
+        text_in = """<iframe src="resolveuid/%s"/>""" % self.UID
+        text_out = """<iframe src="http://nohost/plone/image.jpg/@@images/...jpeg"/>"""
+        self._assertTransformsTo(text_in, text_out)
+
+    def test_video_resolveuid(self):
+        text_in = """<video src="resolveuid/%s"/>""" % self.UID
+        text_out = """<video src="http://nohost/plone/image.jpg/@@images/...jpeg"/>"""
+        self._assertTransformsTo(text_in, text_out)
+
+    def test_audio_resolveuid(self):
+        text_in = """<audio src="resolveuid/%s"/>""" % self.UID
+        text_out = """<audio src="http://nohost/plone/image.jpg/@@images/...jpeg"/>"""
+        self._assertTransformsTo(text_in, text_out)
+
+    def test_source_resolveuid(self):
+        text_in = """<video><source src="resolveuid/%s"/></video>""" % self.UID
+        text_out = """<video><source src="http://nohost/plone/image.jpg/@@images/...jpeg"/></video>"""
+        self._assertTransformsTo(text_in, text_out)
+
+    def test_source_resolveuid_srcset(self):
+        text_in = """<video><source srcset="resolveuid/%s" mimetype="video/mp4"/></video>""" % self.UID
+        text_out = """<video><source srcset="http://nohost/plone/image.jpg/@@images/...jpeg" mimetype="video/mp4"/></video>"""
+        self._assertTransformsTo(text_in, text_out)
+
     def test_image_captioning_resolveuid_no_scale_plone_namedfile(self):
         self._makeDummyContent()
         text_in = """<img class="captioned" src="resolveuid/foo2/@@images/image"/>"""

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -364,7 +364,7 @@ alert(1);
     def test_image_captioning_resolveuid_with_srcset_and_src(self):
         text_in = """<img class="captioned" src="resolveuid/%s/@@images/image" srcset="resolveuid/%s/@@images/image 480w,resolveuid/%s/@@images/image 360w"/>""" % (self.UID, self.UID, self.UID)
         text_out = """<figure class="captioned">
-<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" srcset="http://nohost/plone/image.jpg/@@images/...jpeg 480w,http://nohost/plone/image.jpg/@@images/...jpeg 360w" title="Image" width="500"/>
+<img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" srcset="http://nohost/plone/image.jpg/@@images/image 480w,http://nohost/plone/image.jpg/@@images/image 360w" title="Image" width="500"/>
 <figcaption class="image-caption">My caption</figcaption>
 </figure>"""
         self._assertTransformsTo(text_in, text_out)

--- a/plone/outputfilters/tests/test_resolveuid_and_caption.py
+++ b/plone/outputfilters/tests/test_resolveuid_and_caption.py
@@ -362,8 +362,7 @@ alert(1);
         self._assertTransformsTo(text_in, text_out)
 
     def test_image_captioning_resolveuid_with_srcset_and_src(self):
-        self._makeDummyContent()
-        text_in = """<img class="captioned" src="resolveuid/%s" srcset="resolveuid/%s 480w,resolveuid/%s 360w"/>""" % (self.UID, self.UID, self.UID)
+        text_in = """<img class="captioned" src="resolveuid/%s/@@images/image" srcset="resolveuid/%s/@@images/image 480w,resolveuid/%s/@@images/image 360w"/>""" % (self.UID, self.UID, self.UID)
         text_out = """<figure class="captioned">
 <img alt="My caption" height="331" src="http://nohost/plone/image.jpg/@@images/...jpeg" srcset="http://nohost/plone/image.jpg/@@images/...jpeg 480w,http://nohost/plone/image.jpg/@@images/...jpeg 360w" title="Image" width="500"/>
 <figcaption class="image-caption">My caption</figcaption>


### PR DESCRIPTION
This change ensures that URLs are not output as `resolveuid/...` when served to the user.  This does not particularly affect link integrity when browsing normally, but without this, content in RSS feeds cannot display videos or play audio files.

Related:

* https://github.com/plone/plone.app.linkintegrity/pull/83
* https://github.com/collective/collective.exportimport/pull/95