### PR TITLE
Use our new uuidToObject() from plone.app.uuid.utils

### DIFF
--- a/news/52.bugfix
+++ b/news/52.bugfix
@@ -1,0 +1,2 @@
+Use our new version of uuidToObject() from plone.app.uuid.utils
+[anirudhhkashyap] 

--- a/plone/outputfilters/browser/resolveuid.py
+++ b/plone/outputfilters/browser/resolveuid.py
@@ -5,6 +5,7 @@ from zope.deprecation import deprecate
 from zope.interface import implementer
 from zope.publisher.browser import BrowserView
 from zope.publisher.interfaces import IPublishTraverse
+from plone.app.uuid.utils import uuidToObject as new_uuidToObject
 
 
 try:
@@ -27,11 +28,8 @@ def uuidToURL(uuid):
     "But be aware that this does an extra security check."
 )
 def uuidToObject(uuid):
-    """Resolves a UUID to an object via the UID index of portal_catalog."""
-    catalog = getToolByName(getSite(), "portal_catalog")
-    res = catalog.unrestrictedSearchResults(UID=uuid)
-    if res:
-        return res[0]._unrestrictedGetObject()
+    """Resolves a UUID to an object via the Physical Path"""
+    return new_uuidToObject(uuid, unrestricted=True)
 
 
 try:

--- a/plone/outputfilters/browser/resolveuid.py
+++ b/plone/outputfilters/browser/resolveuid.py
@@ -5,7 +5,7 @@ from zope.deprecation import deprecate
 from zope.interface import implementer
 from zope.publisher.browser import BrowserView
 from zope.publisher.interfaces import IPublishTraverse
-from plone.app.uuid.utils import uuidToObject as new_uuidToObject
+from plone.app.uuid.utils import uuidToObject
 
 
 try:
@@ -23,13 +23,10 @@ def uuidToURL(uuid):
         return res[0].getURL()
 
 
-@deprecate(
-    "Please use plone.app.uuid.utils.uuidToObject instead. "
-    "But be aware that this does an extra security check."
-)
+@deprecate("Import from plone.app.uuid.utils instead. To be removed in version 6.")
 def uuidToObject(uuid):
     """Resolves a UUID to an object via the Physical Path"""
-    return new_uuidToObject(uuid, unrestricted=True)
+    return uuidToObject(uuid, unrestricted=True)
 
 
 try:

--- a/plone/outputfilters/filters/resolveuid_and_caption.py
+++ b/plone/outputfilters/filters/resolveuid_and_caption.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 from DocumentTemplate.DT_Var import newline_to_br
 from DocumentTemplate.html_quote import html_quote
 from plone.base.utils import safe_text
-from plone.outputfilters.browser.resolveuid import uuidToObject
+from plone.app.uuid.utils import uuidToObject
 from plone.outputfilters.interfaces import IFilter
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import IContentish
@@ -274,7 +274,8 @@ class ResolveUIDAndCaptionFilter:
             match = resolveuid_re.match(subpath)
             if match is not None:
                 uid, _subpath = match.groups()
-                obj = uuidToObject(uid)
+                # Getting URL of an object from it's UUID needs no permission checks
+                obj = uuidToObject(uid, unrestricted=True)
                 if obj is not None:
                     subpath = _subpath
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "Products.MimetypesRegistry",
         "Products.PortalTransforms>=2.0",
         "plone.namedfile",
-        "plone.app.uuid",
+        "plone.app.uuid>=2.2.0",
         "setuptools",
         "unidecode",
         "zope.deprecation",


### PR DESCRIPTION
Fixes: #52 

As mentioned, I've used the new `uuidToObject()` from `plone.app.uuid.utils` wherever applicable.