### PR TITLE
Do not return prettified soup after picture variants filter

### DIFF
--- a/news/56.bugfix
+++ b/news/56.bugfix
@@ -1,0 +1,3 @@
+Do not return prettified soup after picture variants filter.
+This prevents adding unneeded newlines.
+[petschki]

--- a/plone/outputfilters/README.rst
+++ b/plone/outputfilters/README.rst
@@ -62,7 +62,7 @@ be applied::
     >>> portal = layer['portal']
     >>> str(portal.portal_transforms.convertTo('text/x-html-safe',
     ...     'test--test', mimetype='text/html', context=portal))
-    'test—test\n'
+    'test—test'
 
 
 How it works

--- a/plone/outputfilters/filters/picture_variants.py
+++ b/plone/outputfilters/filters/picture_variants.py
@@ -47,4 +47,4 @@ class PictureVariantsFilter:
             elem.replace_with(
                 self.img2picturetag.create_picture_tag(sourceset, elem.attrs)
             )
-        return soup.prettify()
+        return str(soup)


### PR DESCRIPTION
the prettified soup adds unneeded newlines.